### PR TITLE
[STHAL] st-hal: Add missing struct definitions

### DIFF
--- a/st_graphite_api.h
+++ b/st_graphite_api.h
@@ -30,7 +30,6 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "graphite_common.h"
 
 #define GCS_DETECTION_ENGINE_CONFIG_KW_DET_ENABLE 0x1
 #define GCS_DETECTION_ENGINE_CONFIG_USER_VER_ENABLE 0x2
@@ -40,6 +39,67 @@
 #define GCS_DETECTION_ENGINE_EVENT_FAILED 1
 
 #define GCS_READ_CMDRSP_STATUS_SUCCESS 0
+
+/* st_hw_session_gcs.c:1608:61
+ * st_hw_session_gcs.c:137:68
+ */
+enum gcs_data_xfer {
+    GCS_XFER_READ,
+};
+
+/* ref: st_hw_session_gcs.c
+ * sound_trigger.sm8150 fields order -- 8.1.r1.
+ * BEWARE --- THIS IS A PACKED STRUCT, ORDER IS IMPORTANT!!!
+ */
+struct graphite_cal_header {
+    uint32_t module_id;
+    uint16_t instance_id;
+    uint16_t reserved;
+    uint32_t param_id;
+    uint32_t size;
+} __packed;
+
+struct graphite_data_cmd_hdr {
+    uint32_t module_id;
+    uint16_t instance_id;
+    uint16_t reserved;
+    uint32_t cmd_id;
+    uint32_t size_in_bytes;
+    uint32_t token;
+} __packed;
+
+struct graphite_data_cmdrsp_hdr {
+    uint32_t module_id;
+    uint16_t instance_id;
+    uint16_t reserved;
+    uint32_t cmd_id;
+    uint32_t size_in_bytes;
+    uint32_t token;
+} __packed;
+
+/*************/
+
+
+/* GCS MODULES */
+
+struct graphite_modinfo {
+    /* st_hw_session_gcs.c line 632 */
+    unsigned int MID;
+    unsigned int IID;
+};
+
+struct gcs_module_param_info { /* st_hw_session_gcs line 522 */
+    struct graphite_modinfo module_info;
+    unsigned int PID; /* st_hw_session_gcs.c line 206 */
+};
+
+struct gcs_event_rsp {
+    struct gcs_module_param_info module_param_info;
+    void *payload;
+    uint32_t payload_size; /* 32bits?? */
+};
+
+/* MODULES END */
 
 struct gcs_det_engine_config_param {
     struct graphite_cal_header cal_hdr;

--- a/st_hw_session_gcs.c
+++ b/st_hw_session_gcs.c
@@ -48,7 +48,7 @@
 #include "sound_trigger_platform.h"
 #include "sound_trigger_hw.h"
 #include "st_graphite_api.h"
-#include "gcs_api.h"
+//#include "gcs_api.h"
 #include "st_hw_common.h"
 
 #define GCS_LIB "libgcs.so"
@@ -109,6 +109,16 @@ static struct st_session_fptrs fptrs_gcs = {
     .process_lab_capture = process_lab_capture,
     .send_detection_request = send_detection_request,
 };
+
+/* Line 170: gcs_event_cb */
+typedef int32_t(*event_cb_ptr)(uint32_t graph_hdl,
+    struct gcs_event_rsp *ev, void *private_data);
+
+/* Line 242: gcs_data_cmdrsp_cb */
+typedef int32_t(*data_cmd_cb_ptr)(uint32_t graph_handle,
+    void *rsp,
+    size_t rsp_size,
+    void *cookie, int32_t cmd_status);
 
 /* gcs functions loaded from dynamic library */
 static int32_t(*gcs_init_fn)(void);


### PR DESCRIPTION
Some struct definitions are strangely missing in this HAL:
rebuild them by looking at the users of these.

Test: Build OK, Functionality OK

Tested on SoMC SM8150 Kumano Griffin DSDS
