### PR TITLE
[ST-HAL] [R] Drop unnecessary COPY_HEADERS

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -97,9 +97,6 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_VENDOR_MODULE := true
 LOCAL_MULTILIB := $(AUDIOSERVER_MULTILIB)
 
-LOCAL_COPY_HEADERS_TO   := mm-audio/sound_trigger
-LOCAL_COPY_HEADERS      := sound_trigger_prop_intf.h
-
 include $(BUILD_SHARED_LIBRARY)
 
 #


### PR DESCRIPTION
`COPY_HEADERS` is rightfully and finally deprecated and dropped on R. Nothing is currently using the `sound_trigger` interface.