### PR TITLE
[9.12] Pick header-include to fix compilation on Android S

### DIFF
--- a/sound_trigger_platform.c
+++ b/sound_trigger_platform.c
@@ -59,6 +59,7 @@ typedef unsigned char __u8;
 #include <cutils/str_parms.h>
 #include <cutils/properties.h>
 #include <cutils/trace.h>
+#include <cutils/bitops.h>
 #include <dlfcn.h>
 #include <expat.h>
 #include <errno.h>


### PR DESCRIPTION
Implicit function declaration error.
added header file.

Change-Id: I7d4b8273e4f8f55dadeb63046125c163d68ba7ce
