### PR TITLE
[9.16.r1] Android.mk: Protect with TARGET_USES_AUDIOREACH flag

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,4 @@
+ifneq ($(TARGET_USES_AUDIOREACH), true)
 ifeq ($(strip $(BOARD_SUPPORTS_OPENSOURCE_STHAL)),true)
 
 LOCAL_PATH := $(call my-dir)
@@ -135,4 +136,5 @@ include $(BUILD_SHARED_LIBRARY)
 #
 #include $(BUILD_EXECUTABLE)
 
+endif
 endif


### PR DESCRIPTION
It so happened that we have a new Audioreach based HAL and legacy
one (pre SM8450 SoC)  at the same time. They use the same module
names, so we must protect them to compile the required one and
prevent conflicts.